### PR TITLE
Changes to only sync matches that don't already exist in the database

### DIFF
--- a/pubg/pubg_api.py
+++ b/pubg/pubg_api.py
@@ -64,17 +64,8 @@ class pubg_api:
         return True
 
 
-    def get_matches(self):
+    def get_matches(self, process_matches):
 
-        process_matches = []
-
-        for player in self.players:
-            for match in player['relationships']['matches']['data']:
-                if match['id'] in process_matches:
-                    continue
-                else:
-                    process_matches.append(match['id'])
-        
         with multiprocessing.Pool() as pool:
             multiprocessed_matches = pool.map(self.get_match, process_matches)
 


### PR DESCRIPTION
Change the get_matches() call to take a predetermined list of match_ids instead of use api.matches. Change sync.py to build the list based on matches not already existing in the database